### PR TITLE
Add ProtobufGenerator to write `ast.File` objects as Proto strings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,11 +35,15 @@ jobs:
         source venv/bin/activate
         pdm run antlr
 
-    - name: Run black and isort
+    - name: Run black
       run: |
         source venv/bin/activate
-        pdm run isort --check --diff proto_schema_parser/ tests/
         pdm run black --check --diff proto_schema_parser/ tests/
+
+    - name: Run isort
+      run: |
+        source venv/bin/activate
+        pdm run isort proto_schema_parser/ tests/ --check-only --diff
 
     - name: Run pylint
       run: |

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -1,0 +1,147 @@
+from proto_schema_parser import ast
+
+
+class ProtobufGenerator:
+    def generate(self, file: ast.File) -> str:
+        lines = []
+
+        # Syntax
+        if file.syntax:
+            lines.append(f'syntax = "{file.syntax}";')
+
+        # File Elements
+        for element in file.file_elements:
+            if isinstance(element, ast.Package):
+                lines.append(f"package {element.name};")
+            elif isinstance(element, ast.Import):
+                modifier = ""
+                if element.weak:
+                    modifier = "weak "
+                elif element.public:
+                    modifier = "public "
+                lines.append(f'import {modifier}"{element.name}";')
+            elif isinstance(element, ast.Option):
+                lines.append(f'option {element.name} = "{element.value}";')
+            elif isinstance(element, ast.Message):
+                lines.append(self._generate_message(element))
+            elif isinstance(element, ast.Enum):
+                lines.append(self._generate_enum(element))
+            elif isinstance(element, ast.Extension):
+                lines.append(self._generate_extension(element))
+
+        return "\n".join(lines)
+
+    def _generate_message(self, message: ast.Message, indent_level: int = 0) -> str:
+        lines = [f"{'  ' * indent_level}message {message.name} {{"]
+        for element in message.elements:
+            if isinstance(element, ast.Field):
+                lines.append(self._generate_field(element, indent_level + 1))
+            elif isinstance(element, ast.MapField):
+                lines.append(self._generate_map_field(element, indent_level + 1))
+            elif isinstance(element, ast.Group):
+                lines.append(self._generate_group(element, indent_level + 1))
+            elif isinstance(element, ast.OneOf):
+                lines.append(self._generate_one_of(element, indent_level + 1))
+            elif isinstance(element, ast.ExtensionRange):
+                lines.append(self._generate_extension_range(element, indent_level + 1))
+            elif isinstance(element, ast.Reserved):
+                lines.append(self._generate_reserved(element, indent_level + 1))
+            elif isinstance(element, ast.Option):
+                lines.append(self._generate_option(element, indent_level + 1))
+            elif isinstance(element, ast.Message):  # Nested Message
+                lines.append(self._generate_message(element, indent_level + 1))
+            elif isinstance(element, ast.Enum):  # Enum
+                lines.append(self._generate_enum(element, indent_level + 1))
+            elif isinstance(element, ast.Extension):  # Extension
+                lines.append(self._generate_extension(element, indent_level + 1))
+        lines.append(f"{'  ' * indent_level}}}")
+        return "\n".join(lines)
+
+    def _generate_field(self, field: ast.Field, indent_level: int = 0) -> str:
+        cardinality = ""
+        if field.cardinality:
+            cardinality = f"{field.cardinality.value.lower()} "
+
+        options = ""
+        if field.options:
+            options = " ["
+            options += ", ".join(f'{opt.name} = "{opt.value}"' for opt in field.options)
+            options += "]"
+
+        return f"{'  ' * indent_level}{cardinality}{field.type} {field.name} = {field.number}{options};"
+
+    def _generate_map_field(
+        self, map_field: ast.MapField, indent_level: int = 0
+    ) -> str:
+        return f"{'  ' * indent_level}map<{map_field.key_type}, {map_field.value_type}> {map_field.name} = {map_field.number};"
+
+    def _generate_group(self, group: ast.Group, indent_level: int = 0) -> str:
+        lines = [f"{'  ' * indent_level}group {group.name} = {group.number} {{"]
+        for element in group.elements:
+            if isinstance(element, ast.Field):
+                lines.append(self._generate_field(element, indent_level + 1))
+            elif isinstance(element, ast.Option):
+                lines.append(self._generate_option(element, indent_level + 1))
+        lines.append(f"{'  ' * indent_level}}}")
+        return "\n".join(lines)
+
+    def _generate_one_of(self, one_of: ast.OneOf, indent_level: int = 0) -> str:
+        lines = [f"{'  ' * indent_level}oneof {one_of.name} {{"]
+        for element in one_of.elements:
+            if isinstance(element, ast.Field):
+                lines.append(self._generate_field(element, indent_level + 1))
+            elif isinstance(element, ast.Option):
+                lines.append(self._generate_option(element, indent_level + 1))
+        lines.append(f"{'  ' * indent_level}}}")
+        return "\n".join(lines)
+
+    def _generate_option(self, option: ast.Option, indent_level: int = 0) -> str:
+        return f"{'  ' * indent_level}option {option.name} = \"{option.value}\";"
+
+    def _generate_extension(
+        self, extension: ast.Extension, indent_level: int = 0
+    ) -> str:
+        lines = [f"{'  ' * indent_level}extend {extension.typeName} {{"]
+        for element in extension.elements:
+            if isinstance(element, ast.Field):
+                lines.append(self._generate_field(element, indent_level + 1))
+            elif isinstance(element, ast.Group):
+                lines.append(self._generate_group(element, indent_level + 1))
+        lines.append(f"{'  ' * indent_level}}}")
+        return "\n".join(lines)
+
+    def _generate_enum(self, enum: ast.Enum, indent_level: int = 0) -> str:
+        lines = [f"{'  ' * indent_level}enum {enum.name} {{"]
+        for element in enum.elements:
+            if isinstance(element, ast.EnumValue):
+                lines.append(
+                    f"{'  ' * (indent_level + 1)}{element.name} = {element.number};"
+                )
+            elif isinstance(element, ast.EnumReserved):
+                lines.append(self._generate_enum_reserved(element, indent_level + 1))
+            elif isinstance(element, ast.Option):
+                lines.append(self._generate_option(element, indent_level + 1))
+        lines.append(f"{'  ' * indent_level}}}")
+        return "\n".join(lines)
+
+    def _generate_enum_reserved(
+        self, reserved: ast.EnumReserved, indent_level: int = 0
+    ) -> str:
+        ranges = ", ".join(reserved.ranges)
+        names = ", ".join(reserved.names)
+        return f"{'  ' * indent_level}reserved {ranges}, {names};"
+
+    def _generate_extension_range(
+        self, extension_range: ast.ExtensionRange, indent_level: int = 0
+    ) -> str:
+        ranges = ", ".join(extension_range.ranges)
+        return f"{'  ' * indent_level}extensions {ranges};"
+
+    def _generate_reserved(self, reserved: ast.Reserved, indent_level: int = 0) -> str:
+        ranges = ", ".join(reserved.ranges)
+        names = ", ".join(reserved.names)
+        return f"{'  ' * indent_level}reserved {ranges}, {names};"
+
+    @staticmethod
+    def _indent(line: str, indent_level: int = 0) -> str:
+        return f"{'  ' * indent_level}{line}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ style = [
 
 [tool.pdm.scripts]
 antlr = "java -Xmx500M -cp antlr/antlr-4.13.0-complete.jar org.antlr.v4.Tool -Dlanguage=Python3 -visitor -o proto_schema_parser -lib proto_schema_parser/antlr antlr/ProtobufLexer.g4 antlr/ProtobufParser.g4"
+black = "black proto_schema_parser/ tests/"
+isort = "isort proto_schema_parser/ tests/"
+style = {composite = ["black", "isort"]}
 
 [tool.black]
 exclude = "proto_schema_parser/antlr/"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,319 @@
+from proto_schema_parser import ast
+from proto_schema_parser.generator import ProtobufGenerator
+
+
+def test_generate_simple_message():
+    message = ast.Message(
+        name="MyMessage",
+        elements=[
+            ast.Field(
+                name="my_field",
+                type="string",
+                number=1,
+                cardinality=ast.FieldCardinality.OPTIONAL,
+            ),
+            ast.Field(
+                name="another_field",
+                type="int32",
+                number=2,
+                cardinality=ast.FieldCardinality.REQUIRED,
+            ),
+        ],
+    )
+
+    result = ProtobufGenerator()._generate_message(message)
+    expected = (
+        "message MyMessage {\n"
+        "  optional string my_field = 1;\n"
+        "  required int32 another_field = 2;\n"
+        "}"
+    )
+
+    assert result == expected
+
+
+def test_generate_package():
+    file = ast.File(file_elements=[ast.Package(name="my.package")])
+
+    result = ProtobufGenerator().generate(file)
+    expected = "package my.package;"
+
+    assert result == expected
+
+
+def test_generate_import():
+    file = ast.File(file_elements=[ast.Import(name="my/import/path.proto")])
+
+    result = ProtobufGenerator().generate(file)
+    expected = 'import "my/import/path.proto";'
+
+    assert result == expected
+
+
+def test_generate_option():
+    file = ast.File(
+        file_elements=[ast.Option(name="java_package", value="com.example.myproto")]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = 'option java_package = "com.example.myproto";'
+
+    assert result == expected
+
+
+def test_generate_enum():
+    file = ast.File(
+        file_elements=[
+            ast.Enum(
+                name="MyEnum",
+                elements=[
+                    ast.EnumValue(name="FIRST_VALUE", number=0),
+                    ast.EnumValue(name="SECOND_VALUE", number=1),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = "enum MyEnum {\n" "  FIRST_VALUE = 0;\n" "  SECOND_VALUE = 1;\n" "}"
+
+    assert result == expected
+
+
+def test_generate_extension():
+    file = ast.File(
+        file_elements=[
+            ast.Extension(
+                typeName="ExtendeeType",
+                elements=[
+                    ast.Field(
+                        name="ext_field",
+                        type="string",
+                        number=1,
+                        cardinality=ast.FieldCardinality.OPTIONAL,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = "extend ExtendeeType {\n" "  optional string ext_field = 1;\n" "}"
+
+    assert result == expected
+
+
+def test_generate_nested_message():
+    file = ast.File(
+        file_elements=[
+            ast.Message(
+                name="OuterMessage",
+                elements=[
+                    ast.Message(
+                        name="InnerMessage",
+                        elements=[
+                            ast.Field(
+                                name="inner_field",
+                                type="int32",
+                                number=1,
+                                cardinality=ast.FieldCardinality.REQUIRED,
+                            ),
+                        ],
+                    ),
+                    ast.Field(
+                        name="outer_field",
+                        type="InnerMessage",
+                        number=2,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = (
+        "message OuterMessage {\n"
+        "  message InnerMessage {\n"
+        "    required int32 inner_field = 1;\n"
+        "  }\n"
+        "  InnerMessage outer_field = 2;\n"
+        "}"
+    )
+
+    assert result == expected
+
+
+def test_generate_map_field():
+    map_field = ast.MapField(
+        name="my_map",
+        key_type="string",
+        value_type="int32",
+        number=2,
+    )
+
+    result = ProtobufGenerator()._generate_map_field(map_field)
+    expected = "map<string, int32> my_map = 2;"
+
+    assert result == expected
+
+
+def test_generate_group():
+    group = ast.Group(
+        name="MyGroup",
+        number=1,
+        elements=[
+            ast.Field(
+                name="my_field",
+                type="string",
+                number=2,
+                cardinality=ast.FieldCardinality.OPTIONAL,
+            ),
+        ],
+    )
+
+    result = ProtobufGenerator()._generate_group(group)
+    expected = "group MyGroup = 1 {\n" "  optional string my_field = 2;\n" "}"
+
+    assert result == expected
+
+
+def test_generate_one_of():
+    file = ast.File(
+        file_elements=[
+            ast.Message(
+                name="MyMessage",
+                elements=[
+                    ast.OneOf(
+                        name="my_one_of",
+                        elements=[
+                            ast.Field(
+                                name="my_field",
+                                type="string",
+                                number=1,
+                                cardinality=ast.FieldCardinality.OPTIONAL,
+                            ),
+                            ast.Field(
+                                name="my_field_2",
+                                type="int32",
+                                number=2,
+                                cardinality=ast.FieldCardinality.OPTIONAL,
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = (
+        "message MyMessage {\n"
+        "  oneof my_one_of {\n"
+        "    optional string my_field = 1;\n"
+        "    optional int32 my_field_2 = 2;\n"
+        "  }\n"
+        "}"
+    )
+
+    assert result == expected
+
+
+def test_generate_extension_range():
+    file = ast.File(
+        file_elements=[
+            ast.Message(
+                name="MyMessage",
+                elements=[
+                    ast.ExtensionRange(
+                        ranges=["100 to 199", "300 to max"],
+                    ),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = "message MyMessage {\n" "  extensions 100 to 199, 300 to max;\n" "}"
+
+    assert result == expected
+
+
+def test_generate_reserved():
+    file = ast.File(
+        file_elements=[
+            ast.Message(
+                name="MyMessage",
+                elements=[
+                    ast.Reserved(
+                        ranges=["1 to 8", "10", "12"],
+                        names=['"foo"', '"bar"'],
+                    ),
+                ],
+            )
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = "message MyMessage {\n" '  reserved 1 to 8, 10, 12, "foo", "bar";\n' "}"
+
+    assert result == expected
+
+
+def test_generate_with_options():
+    file = ast.File(
+        file_elements=[
+            ast.Option(name="java_package", value="com.example.myproto"),
+            ast.Message(
+                name="MyMessage",
+                elements=[
+                    ast.Option(name="deprecated", value="true"),
+                    ast.Field(
+                        name="my_field",
+                        type="string",
+                        number=1,
+                        options=[ast.Option(name="default", value="default_value")],
+                    ),
+                    ast.OneOf(
+                        name="my_oneof",
+                        elements=[
+                            ast.Option(name="deprecated", value="true"),
+                            ast.Field(
+                                name="oneof_field",
+                                type="string",
+                                number=2,
+                                options=[
+                                    ast.Option(name="default", value="oneof_default")
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ast.Enum(
+                name="MyEnum",
+                elements=[
+                    ast.Option(name="allow_alias", value="true"),
+                    ast.EnumValue(name="FIRST_VALUE", number=0),
+                ],
+            ),
+        ]
+    )
+
+    result = ProtobufGenerator().generate(file)
+    expected = (
+        'option java_package = "com.example.myproto";\n'
+        "message MyMessage {\n"
+        '  option deprecated = "true";\n'
+        '  string my_field = 1 [default = "default_value"];\n'
+        "  oneof my_oneof {\n"
+        '    option deprecated = "true";\n'
+        '    string oneof_field = 2 [default = "oneof_default"];\n'
+        "  }\n"
+        "}\n"
+        "enum MyEnum {\n"
+        '  option allow_alias = "true";\n'
+        "  FIRST_VALUE = 0;\n"
+        "}"
+    )
+
+    assert result == expected


### PR DESCRIPTION
`proto-schema-parser` can now seralize Protobuf represented as `ast.File` objects back into Protobuf schema strings.

The `ProtobufGenerator` class will converter:

```python
ast.Message(
    name="MyMessage",
    elements=[
        ast.Field(
            name="my_field",
            type="string",
            number=1,
            cardinality=ast.FieldCardinality.OPTIONAL,
        ),
        ast.Field(
            name="another_field",
            type="int32",
            number=2,
            cardinality=ast.FieldCardinality.REQUIRED,
        ),
    ],
)
```

To:

```protobuf
message MyMessage {
  optional string my_field = 1;
  required int32 another_field = 2;
"
```