### PR TITLE
Fix generating reserved when there are only ranges or only names

### DIFF
--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -1,5 +1,6 @@
-from proto_schema_parser import ast
 import itertools
+
+from proto_schema_parser import ast
 
 
 class Generator:

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -1,4 +1,5 @@
 from proto_schema_parser import ast
+import itertools
 
 
 class Generator:
@@ -196,9 +197,8 @@ class Generator:
         return f"{'  ' * indent_level}extensions {ranges};"
 
     def _generate_reserved(self, reserved: ast.Reserved, indent_level: int = 0) -> str:
-        ranges = ", ".join(reserved.ranges)
-        names = ", ".join(reserved.names)
-        return f"{'  ' * indent_level}reserved {ranges}, {names};"
+        reserved_values = ", ".join(itertools.chain(reserved.ranges, reserved.names))
+        return f"{'  ' * indent_level}reserved {reserved_values};"
 
     @staticmethod
     def _indent(line: str, indent_level: int = 0) -> str:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -276,13 +276,21 @@ def test_generate_reserved():
                         ranges=["1 to 8", "10", "12"],
                         names=['"foo"', '"bar"'],
                     ),
+                    ast.Reserved(
+                        ranges=["13 to 17", "27", "54"],
+                        names=[],
+                    ),
+                    ast.Reserved(
+                        ranges=[],
+                        names=['"spam"', '"spamspam"'],
+                    ),
                 ],
             )
         ]
     )
 
     result = Generator().generate(file)
-    expected = "message MyMessage {\n" '  reserved 1 to 8, 10, 12, "foo", "bar";\n' "}"
+    expected = "message MyMessage {\n" '  reserved 1 to 8, 10, 12, "foo", "bar";\n  reserved 13 to 17, 27, 54;\n  reserved "spam", "spamspam";\n' "}"
 
     assert result == expected
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -290,7 +290,11 @@ def test_generate_reserved():
     )
 
     result = Generator().generate(file)
-    expected = "message MyMessage {\n" '  reserved 1 to 8, 10, 12, "foo", "bar";\n  reserved 13 to 17, 27, 54;\n  reserved "spam", "spamspam";\n' "}"
+    expected = (
+        "message MyMessage {\n"
+        '  reserved 1 to 8, 10, 12, "foo", "bar";\n  reserved 13 to 17, 27, 54;\n  reserved "spam", "spamspam";\n'
+        "}"
+    )
 
     assert result == expected
 


### PR DESCRIPTION
Now, if you have `reserved` that have only ranges or only names in them, the generator will produce proto schema with dangling commas.
So:
```python
ast.File(
        file_elements=[
            ast.Message(
                name="MyMessage",
                elements=[
                    ast.Reserved(
                        ranges=["13 to 17", "27", "54"],
                        names=[],
                    ),
                    ast.Reserved(
                        ranges=[],
                        names=['"spam"', '"spamspam"'],
                    ),
                ],
            )
        ]
    )
```
will poduce:
```protobuf
message MyMessage {
      reserved 13 to 17, 27, 54, ;
      reserved , "spam", "spamspam";
}
```

This PR fixes it.