### PR TITLE
Support message literals

### DIFF
--- a/proto_schema_parser/ast.py
+++ b/proto_schema_parser/ast.py
@@ -37,6 +37,7 @@ class Import:
     weak: bool = False
     public: bool = False
 
+
 @dataclass
 class MessageLiteralField:
     name: str
@@ -251,4 +252,4 @@ MethodElement = Union[Option, Comment]
 ScalarValue = Union[str, int, float, bool, Identifier]
 
 # Define a recursive type alias for message values
-MessageValue = Union[ScalarValue, MessageLiteral, List['MessageValue']]
+MessageValue = Union[ScalarValue, MessageLiteral, List["MessageValue"]]

--- a/proto_schema_parser/ast.py
+++ b/proto_schema_parser/ast.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum as PyEnum
-from typing import Optional, Union
+from typing import List, Union
 
 
 class FieldCardinality(str, PyEnum):
@@ -37,12 +37,23 @@ class Import:
     weak: bool = False
     public: bool = False
 
+@dataclass
+class MessageLiteralField:
+    name: str
+    value: MessageValue
+
+
+@dataclass
+class MessageLiteral:
+    fields: List[MessageLiteralField] = field(default_factory=list)
+
 
 # optionDecl: OPTION optionName EQUALS optionValue SEMICOLON;
 @dataclass
+@dataclass
 class Option:
     name: str
-    value: Union[str, int, float, bool, Identifier]
+    value: Union[ScalarValue, MessageLiteral]
 
 
 # messageDecl: MESSAGE messageName L_BRACE messageElement* R_BRACE;
@@ -223,7 +234,7 @@ EnumElement = Union[Option, EnumValue, EnumReserved, Comment]
 
 # extensionElement: extensionFieldDecl |
 #                     groupDecl;
-ExtensionElement = Union[Field, Group]
+ExtensionElement = Union[Field, Group, Comment]
 
 # serviceElement: optionDecl |
 #                   methodDecl |
@@ -235,3 +246,9 @@ ServiceElement = Union[Option, Method, Comment]
 #                 commentDecl |
 #                 emptyDecl;
 MethodElement = Union[Option, Comment]
+
+# Define a type alias for scalar values
+ScalarValue = Union[str, int, float, bool, Identifier]
+
+# Define a recursive type alias for message values
+MessageValue = Union[ScalarValue, MessageLiteral, List['MessageValue']]

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -212,6 +212,8 @@ class Generator:
             if i < len(message_literal.fields) - 1:
                 lines[-1] += ","  # Add a comma except for the last field
         lines.append(f"{'  ' * indent_level}}}")
+        if len(lines) == 2:
+            lines = ["{}"]  # Don't include a linebreak if there are no fields
         return "\n".join(lines)
 
     def _generate_message_literal_field(self, field: ast.MessageLiteralField, indent_level: int) -> str:
@@ -226,24 +228,42 @@ class Generator:
             # same line as the field name.
             return self._generate_message_literal(value, indent_level).strip()
         elif isinstance(value, list):
-            return self._generate_list_literal(value)
+            # No + 1 for indent_level since the list literal is on the same line as the field name.
+            return self._generate_list_literal(value, indent_level)
         else:
             return self._generate_scalar(value)
 
-    def _generate_list_literal(self, elements: list[ast.MessageValue]) -> str:
+    def _generate_list_literal(self, elements: list[ast.MessageValue], indent_level: int) -> str:
         """Generate a list literal."""
-        element_strings = [self._generate_scalar(el) for el in elements]
-        return f"[{', '.join(element_strings)}]"
+        message_values = [self._generate_option_value(element, indent_level) for element in elements]
+        return f"[{', '.join(message_values)}]"
 
     def _generate_scalar(self, scalar: ast.ScalarValue) -> str:
         """Generate scalar values like strings, numbers, or identifiers."""
         if isinstance(scalar, str):
-            return f'"{scalar}"'
+            return f'"{self._escape_string(scalar)}"'
         elif isinstance(scalar, ast.Identifier):
             return scalar.name
         elif isinstance(scalar, bool):
             return "true" if scalar else "false"
         return str(scalar)
+
+    def _escape_string(self, value: str) -> str:
+        """
+        Escapes a string so it is safe to use as a scalar string value
+        in a Protobuf definition.
+        """
+        # Define the escape mappings for special characters
+        escape_map = {
+            '\\': '\\\\',  # Backslash
+            '"': '\\"',    # Double quote
+            '\n': '\\n',   # Newline
+            '\t': '\\t',   # Tab
+            '\r': '\\r',   # Carriage return
+        }
+
+        # Use the escape map to replace special characters
+        return ''.join(escape_map.get(char, char) for char in value)
 
     @staticmethod
     def _indent(line: str, indent_level: int = 0) -> str:

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -203,7 +203,9 @@ class Generator:
         reserved_values = ", ".join(itertools.chain(reserved.ranges, reserved.names))
         return f"{'  ' * indent_level}reserved {reserved_values};"
 
-    def _generate_message_literal(self, message_literal: ast.MessageLiteral, indent_level: int) -> str:
+    def _generate_message_literal(
+        self, message_literal: ast.MessageLiteral, indent_level: int
+    ) -> str:
         """Generate nested message literal with consistent indentation."""
         lines = [f"{'  ' * indent_level}{{"]
         for i, field in enumerate(message_literal.fields):
@@ -216,7 +218,9 @@ class Generator:
             lines = ["{}"]  # Don't include a linebreak if there are no fields
         return "\n".join(lines)
 
-    def _generate_message_literal_field(self, field: ast.MessageLiteralField, indent_level: int) -> str:
+    def _generate_message_literal_field(
+        self, field: ast.MessageLiteralField, indent_level: int
+    ) -> str:
         """Generate individual field with correct indentation."""
         value = self._generate_option_value(field.value, indent_level)
         return f"{'  ' * indent_level}{field.name}: {value}"
@@ -233,9 +237,13 @@ class Generator:
         else:
             return self._generate_scalar(value)
 
-    def _generate_list_literal(self, elements: list[ast.MessageValue], indent_level: int) -> str:
+    def _generate_list_literal(
+        self, elements: list[ast.MessageValue], indent_level: int
+    ) -> str:
         """Generate a list literal."""
-        message_values = [self._generate_option_value(element, indent_level) for element in elements]
+        message_values = [
+            self._generate_option_value(element, indent_level) for element in elements
+        ]
         return f"[{', '.join(message_values)}]"
 
     def _generate_scalar(self, scalar: ast.ScalarValue) -> str:
@@ -255,15 +263,15 @@ class Generator:
         """
         # Define the escape mappings for special characters
         escape_map = {
-            '\\': '\\\\',  # Backslash
-            '"': '\\"',    # Double quote
-            '\n': '\\n',   # Newline
-            '\t': '\\t',   # Tab
-            '\r': '\\r',   # Carriage return
+            "\\": "\\\\",  # Backslash
+            '"': '\\"',  # Double quote
+            "\n": "\\n",  # Newline
+            "\t": "\\t",  # Tab
+            "\r": "\\r",  # Carriage return
         }
 
         # Use the escape map to replace special characters
-        return ''.join(escape_map.get(char, char) for char in value)
+        return "".join(escape_map.get(char, char) for char in value)
 
     @staticmethod
     def _indent(line: str, indent_level: int = 0) -> str:

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -46,7 +46,9 @@ class ASTConstructor(ProtobufParserVisitor):
         else:
             return self._getText(ctx)
 
-    def visitMessageLiteralWithBraces(self, ctx: ProtobufParser.MessageLiteralWithBracesContext):
+    def visitMessageLiteralWithBraces(
+        self, ctx: ProtobufParser.MessageLiteralWithBracesContext
+    ):
         return self.visit(ctx.messageTextFormat())
 
     def visitMessageTextFormat(self, ctx: ProtobufParser.MessageTextFormatContext):
@@ -271,7 +273,9 @@ class ASTConstructor(ProtobufParserVisitor):
         else:
             return self._getText(ctx)
 
-    def visitScalarValue(self, ctx: ProtobufParser.ScalarValueContext) -> ast.ScalarValue:
+    def visitScalarValue(
+        self, ctx: ProtobufParser.ScalarValueContext
+    ) -> ast.ScalarValue:
         if ctx.stringLiteral():
             return self._getText(ctx.stringLiteral())
         elif ctx.intLiteral():

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -1,6 +1,6 @@
 # pyright: reportOptionalMemberAccess=false, reportOptionalIterable=false
 
-from typing import Any
+from typing import Any, List
 
 from antlr4 import CommonTokenStream, InputStream
 
@@ -41,8 +41,28 @@ class ASTConstructor(ProtobufParserVisitor):
     def visitOptionValue(self, ctx: ProtobufParser.OptionValueContext):
         if ctx.scalarValue():
             return self.visit(ctx.scalarValue())
+        elif ctx.messageLiteralWithBraces():
+            return self.visit(ctx.messageLiteralWithBraces())
+        else:
+            return self._getText(ctx)
 
-        return self._getText(ctx)
+    def visitMessageLiteralWithBraces(self, ctx: ProtobufParser.MessageLiteralWithBracesContext):
+        return self.visit(ctx.messageTextFormat())
+
+    def visitMessageTextFormat(self, ctx: ProtobufParser.MessageTextFormatContext):
+        if ctx.messageLiteralField():
+            fields = [self.visit(child) for child in ctx.messageLiteralField()]
+            return ast.MessageLiteral(fields=fields)
+        elif ctx.commentDecl():
+            return self.visit(ctx.commentDecl())
+        else:
+            return self._getText(ctx)
+
+    def visitMessageLiteralField(self, ctx: ProtobufParser.MessageLiteralFieldContext):
+        """Parse individual fields inside a message literal."""
+        name = self._getText(ctx.messageLiteralFieldName())
+        value = self.visit(ctx.value())
+        return ast.MessageLiteralField(name=name, value=value)
 
     def visitMessageDecl(self, ctx: ProtobufParser.MessageDeclContext):
         name = self._getText(ctx.messageName())
@@ -218,7 +238,7 @@ class ASTConstructor(ProtobufParserVisitor):
         elif commentDecl := ctx.commentDecl():
             return self.visit(commentDecl)
         else:
-            raise AttributeError("invalid service element")
+            return self._getText(ctx)
 
     def visitMethodDecl(self, ctx: ProtobufParser.MethodDeclContext):
         name = self._getText(ctx.methodName())
@@ -249,20 +269,43 @@ class ASTConstructor(ProtobufParserVisitor):
         elif commentDecl := ctx.commentDecl():
             return self.visit(commentDecl)
         else:
-            raise AttributeError("invalid method element")
+            return self._getText(ctx)
 
-    def visitScalarValue(self, ctx: ProtobufParser.ScalarValueContext):
+    def visitScalarValue(self, ctx: ProtobufParser.ScalarValueContext) -> ast.ScalarValue:
         if ctx.stringLiteral():
             return self._getText(ctx.stringLiteral())
-        elif ctx.intLiteral() or ctx.floatLiteral():
-            return self._stringToType(self._getText(ctx))
+        elif ctx.intLiteral():
+            return self._stringToType(self._getText(ctx.intLiteral()))
+        elif ctx.floatLiteral():
+            return self._stringToType(self._getText(ctx.floatLiteral()))
         elif ctx.specialFloatLiteral():
-            # TODO Handle specialFloatLiteral -inf, inf, nan properly
-            return self._getText(ctx)
+            return self._stringToType(self._getText(ctx.specialFloatLiteral()))
         elif ctx.identifier():
-            return self.visit(ctx.identifier())
-        # ctx.identifier()
-        return self.visit(ctx.identifier())
+            identifier_text = self._getText(ctx.identifier())
+            if identifier_text in ["true", "false"]:
+                return identifier_text == "true"
+            else:
+                return ast.Identifier(name=identifier_text)
+        else:
+            return self._getText(ctx)
+
+    def visitIdentifier(self, ctx: ProtobufParser.IdentifierContext) -> ast.Identifier:
+        return ast.Identifier(name=self._getText(ctx))
+
+    def visitValue(self, ctx: ProtobufParser.ValueContext) -> ast.MessageValue:
+        if ctx.scalarValue():
+            return self.visit(ctx.scalarValue())
+        elif ctx.messageLiteral():
+            return self.visit(ctx.messageLiteral())
+        elif ctx.listLiteral():
+            return self.visit(ctx.listLiteral())
+        else:
+            return self._getText(ctx)
+
+    def visitListLiteral(self, ctx: ProtobufParser.ListLiteralContext):
+        """Parse list literals."""
+        elements = [self.visit(element) for element in ctx.listElement()]
+        return elements
 
     def visitAlwaysIdent(self, ctx: ProtobufParser.AlwaysIdentContext):
         if ctx.IDENTIFIER():

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -594,12 +594,8 @@ def test_generate_message_literal_with_braces():
                         name="(custom_option)",
                         value=ast.MessageLiteral(
                             fields=[
-                                ast.MessageLiteralField(
-                                    name="field1", value="value1"
-                                ),
-                                ast.MessageLiteralField(
-                                    name="field2", value=42
-                                ),
+                                ast.MessageLiteralField(name="field1", value="value1"),
+                                ast.MessageLiteralField(name="field2", value=42),
                                 ast.MessageLiteralField(
                                     name="nested_field",
                                     value=ast.MessageLiteral(
@@ -656,12 +652,7 @@ def test_generate_option_with_simple_message_literal():
     )
 
     result = Generator()._generate_option(option)
-    expected = (
-        "option my_option = {\n"
-        '  field1: "value1",\n'
-        "  field2: 42\n"
-        "};"
-    )
+    expected = "option my_option = {\n" '  field1: "value1",\n' "  field2: 42\n" "};"
 
     assert result == expected
 
@@ -674,9 +665,7 @@ def test_generate_option_with_nested_message_literal():
                 ast.MessageLiteralField(
                     name="outer_field",
                     value=ast.MessageLiteral(
-                        fields=[
-                            ast.MessageLiteralField(name="inner_field", value=True)
-                        ]
+                        fields=[ast.MessageLiteralField(name="inner_field", value=True)]
                     ),
                 )
             ]
@@ -713,11 +702,7 @@ def test_generate_option_with_list_literal():
     )
 
     result = Generator()._generate_option(option)
-    expected = (
-        "option list_option = {\n"
-        "  field: [1, 2, 3]\n"
-        "};"
-    )
+    expected = "option list_option = {\n" "  field: [1, 2, 3]\n" "};"
 
     assert result == expected
 
@@ -747,11 +732,7 @@ def test_generate_option_with_identifier():
     )
 
     result = Generator()._generate_option(option)
-    expected = (
-        "option identifier_option = {\n"
-        "  id: MyIdentifier\n"
-        "};"
-    )
+    expected = "option identifier_option = {\n" "  id: MyIdentifier\n" "};"
 
     assert result == expected
 
@@ -848,12 +829,8 @@ def test_generate_option_with_message_literal_in_message():
                         name="(custom_option)",
                         value=ast.MessageLiteral(
                             fields=[
-                                ast.MessageLiteralField(
-                                    name="field1", value="value1"
-                                ),
-                                ast.MessageLiteralField(
-                                    name="field2", value=42
-                                ),
+                                ast.MessageLiteralField(name="field1", value="value1"),
+                                ast.MessageLiteralField(name="field2", value=42),
                                 ast.MessageLiteralField(
                                     name="nested_field",
                                     value=ast.MessageLiteral(
@@ -910,12 +887,8 @@ def test_generate_service_with_option_message_literal():
                         name="service_option",
                         value=ast.MessageLiteral(
                             fields=[
-                                ast.MessageLiteralField(
-                                    name="bool_field", value=True
-                                ),
-                                ast.MessageLiteralField(
-                                    name="number_field", value=123
-                                ),
+                                ast.MessageLiteralField(name="bool_field", value=True),
+                                ast.MessageLiteralField(name="number_field", value=123),
                                 ast.MessageLiteralField(
                                     name="string_field", value="test"
                                 ),
@@ -1022,18 +995,12 @@ def test_generate_option_with_empty_list():
     option = ast.Option(
         name="empty_list_option",
         value=ast.MessageLiteral(
-            fields=[
-                ast.MessageLiteralField(name="items", value=[])
-            ]
+            fields=[ast.MessageLiteralField(name="items", value=[])]
         ),
     )
 
     result = Generator()._generate_option(option)
-    expected = (
-        "option empty_list_option = {\n"
-        "  items: []\n"
-        "};"
-    )
+    expected = "option empty_list_option = {\n" "  items: []\n" "};"
 
     assert result == expected
 
@@ -1044,7 +1011,9 @@ def test_generate_option_with_special_float_values():
         value=ast.MessageLiteral(
             fields=[
                 ast.MessageLiteralField(name="infinite", value=ast.Identifier("inf")),
-                ast.MessageLiteralField(name="negative_infinite", value=ast.Identifier("-inf")),
+                ast.MessageLiteralField(
+                    name="negative_infinite", value=ast.Identifier("-inf")
+                ),
                 ast.MessageLiteralField(name="nan_value", value=ast.Identifier("nan")),
             ]
         ),
@@ -1075,10 +1044,7 @@ def test_generate_option_with_boolean_values():
 
     result = Generator()._generate_option(option)
     expected = (
-        "option bool_option = {\n"
-        "  flag_true: true,\n"
-        "  flag_false: false\n"
-        "};"
+        "option bool_option = {\n" "  flag_true: true,\n" "  flag_false: false\n" "};"
     )
 
     assert result == expected

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -581,3 +581,64 @@ def test_generate_service_with_numeric_option():
     )
 
     assert result == expected
+
+
+def test_generate_message_literal_with_braces():
+    file = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Message(
+                name="SearchRequest",
+                elements=[
+                    ast.Option(
+                        name="(custom_option)",
+                        value=ast.MessageLiteral(
+                            fields=[
+                                ast.MessageLiteralField(
+                                    name="field1", value="value1"
+                                ),
+                                ast.MessageLiteralField(
+                                    name="field2", value=42
+                                ),
+                                ast.MessageLiteralField(
+                                    name="nested_field",
+                                    value=ast.MessageLiteral(
+                                        fields=[
+                                            ast.MessageLiteralField(
+                                                name="key1", value="nested_value1"
+                                            ),
+                                            ast.MessageLiteralField(
+                                                name="key2", value=[1, 2, 3]
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                    ast.Field(
+                        name="query",
+                        number=1,
+                        type="string",
+                        options=[],
+                    ),
+                ],
+            ),
+        ],
+    )
+    result = Generator().generate(file)
+    expected = (
+        'syntax = "proto3";\n'
+        "message SearchRequest {\n"
+        "  option (custom_option) = {\n"
+        '    field1: "value1",\n'
+        "    field2: 42,\n"
+        "    nested_field: {\n"
+        '      key1: "nested_value1",\n'
+        "      key2: [1, 2, 3]\n"
+        "    }\n"
+        "  };\n"
+        "  string query = 1;\n"
+        "}"
+    )
+    assert result == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1224,12 +1224,8 @@ def test_parse_message_literal_with_braces():
                         name="(custom_option)",
                         value=ast.MessageLiteral(
                             fields=[
-                                ast.MessageLiteralField(
-                                    name="field1", value="value1"
-                                ),
-                                ast.MessageLiteralField(
-                                    name="field2", value=42
-                                ),
+                                ast.MessageLiteralField(name="field1", value="value1"),
+                                ast.MessageLiteralField(name="field2", value=42),
                                 ast.MessageLiteralField(
                                     name="nested_field",
                                     value=ast.MessageLiteral(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1257,3 +1257,185 @@ def test_parse_message_literal_with_braces():
         ],
     )
     assert result == expected
+
+
+def test_option_with_scalar_values():
+    text = """
+    syntax = "proto3";
+
+    service TestService {
+        rpc TestMethod (TestRequest) returns (TestResponse) {
+            option (test.option) = { int_field: 123 };
+            option (test.option) = { float_field: 45.67 };
+            option (test.option) = { bool_field: true };
+            option (test.option) = { string_field: "Hello" };
+        }
+    }
+    """
+    result = Parser().parse(text)
+
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Service(
+                name="TestService",
+                elements=[
+                    ast.Method(
+                        name="TestMethod",
+                        input_type=ast.MessageType(type="TestRequest"),
+                        output_type=ast.MessageType(type="TestResponse"),
+                        elements=[
+                            ast.Option(
+                                name="(test.option)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="int_field", value=123
+                                        )
+                                    ]
+                                ),
+                            ),
+                            ast.Option(
+                                name="(test.option)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="float_field", value=45.67
+                                        )
+                                    ]
+                                ),
+                            ),
+                            ast.Option(
+                                name="(test.option)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="bool_field", value=True
+                                        )
+                                    ]
+                                ),
+                            ),
+                            ast.Option(
+                                name="(test.option)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="string_field", value="Hello"
+                                        )
+                                    ]
+                                ),
+                            ),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert result == expected
+
+
+def test_option_with_nested_message_literal():
+    text = """
+    syntax = "proto3";
+
+    service NestedService {
+        rpc NestedMethod (Request) returns (Response) {
+            option (test.nested) = {
+                inner: { field1: "abc", field2: 42 }
+            };
+        }
+    }
+    """
+    result = Parser().parse(text)
+
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Service(
+                name="NestedService",
+                elements=[
+                    ast.Method(
+                        name="NestedMethod",
+                        input_type=ast.MessageType(type="Request"),
+                        output_type=ast.MessageType(type="Response"),
+                        elements=[
+                            ast.Option(
+                                name="(test.nested)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="inner",
+                                            value=ast.MessageLiteral(
+                                                fields=[
+                                                    ast.MessageLiteralField(
+                                                        name="field1", value="abc"
+                                                    ),
+                                                    ast.MessageLiteralField(
+                                                        name="field2", value=42
+                                                    ),
+                                                ]
+                                            ),
+                                        )
+                                    ]
+                                ),
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert result == expected
+
+
+def test_option_with_comments_and_fields():
+    text = """
+    syntax = "proto3";
+
+    service CommentService {
+        rpc CommentMethod (Request) returns (Response) {
+            option (test.option) = {
+                // Comment about the field
+                field1: "value1";
+                field2: 99;
+                // Another comment
+            };
+        }
+    }
+    """
+    result = Parser().parse(text)
+
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Service(
+                name="CommentService",
+                elements=[
+                    ast.Method(
+                        name="CommentMethod",
+                        input_type=ast.MessageType(type="Request"),
+                        output_type=ast.MessageType(type="Response"),
+                        elements=[
+                            ast.Option(
+                                name="(test.option)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="field1", value="value1"
+                                        ),
+                                        ast.MessageLiteralField(
+                                            name="field2", value=99
+                                        ),
+                                    ]
+                                ),
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert result == expected


### PR DESCRIPTION
I've added full support for message literals in option values. This involved adding a couple of new AST types:

- Added `MessageLiteral`, `MessageLiteralField`, and `MessageValue` types.
- Updated `Option` to contain either `ScalaerValue` or `MessageLiteral`

Message literals contain a list of fields. Each field has a name and a value. The value can be a scalar value (1, 2, "foo", true), or a message literal (nested). It can also be a list (`[1, 2, <some message literal>]`).