### PR TITLE
Add support for `listOfMessagesLiteral` in `messgaeValue`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python3.10 -m venv venv
+        python3 -m venv venv
         source venv/bin/activate
         pip install pdm
         pdm install

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -97,7 +97,7 @@ class Generator:
             isinstance(element, ast.Option) for element in method.elements
         )
         lines = [
-            f"{'  ' * indent_level}rpc {method.name} ({input_type_str}) returns ({output_type_str}){'{' if has_options else ';'}"
+            f"{'  ' * indent_level}rpc {method.name} ({input_type_str}) returns ({output_type_str}){' {' if has_options else ';'}"
         ]
         if has_options:
             for element in method.elements:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1177,44 +1177,38 @@ def test_generate_service_with_additional_bindings():
                         value=ast.MessageLiteral(
                             fields=[
                                 ast.MessageLiteralField(
-                                    name="post",
-                                    value="/v3/lease/revoke"
+                                    name="post", value="/v3/lease/revoke"
                                 ),
-                                ast.MessageLiteralField(
-                                    name="body",
-                                    value="*"
-                                ),
+                                ast.MessageLiteralField(name="body", value="*"),
                                 ast.MessageLiteralField(
                                     name="additional_bindings",
                                     value=ast.MessageLiteral(
                                         fields=[
                                             ast.MessageLiteralField(
-                                                name="post",
-                                                value="/v3/kv/lease/revoke"
+                                                name="post", value="/v3/kv/lease/revoke"
                                             ),
                                             ast.MessageLiteralField(
-                                                name="body",
-                                                value="*"
-                                            )
+                                                name="body", value="*"
+                                            ),
                                         ]
-                                    )
-                                )
+                                    ),
+                                ),
                             ]
-                        )
+                        ),
                     )
-                ]
+                ],
             )
-        ]
+        ],
     )
 
     result = Generator()._generate_service(service)
     expected = (
         "service Lease {\n"
         "  rpc LeaseRevoke (LeaseRevokeRequest) returns (LeaseRevokeResponse) {\n"
-        '    option (google.api.http) = {\n'
+        "    option (google.api.http) = {\n"
         '      post: "/v3/lease/revoke",\n'
         '      body: "*",\n'
-        '      additional_bindings: {\n'
+        "      additional_bindings: {\n"
         '        post: "/v3/kv/lease/revoke",\n'
         '        body: "*"\n'
         "      }\n"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -392,7 +392,7 @@ def test_generate_service():
         "service MyService {\n"
         "  rpc MyRpc (MyRequest) returns (MyResponse);\n"
         "  rpc MyRpcWithStream (stream MyRequest) returns (MyResponse);\n"
-        "  rpc MyRpcWithOption (MyRequest) returns (MyResponse){\n"
+        "  rpc MyRpcWithOption (MyRequest) returns (MyResponse) {\n"
         '    option deprecated = "true";\n'
         "  }\n"
         '  option MyOption = "foo";\n'
@@ -937,7 +937,7 @@ def test_generate_service_with_option_message_literal():
         '    string_field: "test",\n'
         '    list_field: ["a", "b"]\n'
         "  };\n"
-        "  rpc TestMethod (TestRequest) returns (TestResponse){\n"
+        "  rpc TestMethod (TestRequest) returns (TestResponse) {\n"
         "    option method_option = {\n"
         "      inner_option: {\n"
         "        enabled: false\n"
@@ -1160,3 +1160,67 @@ def test_generate_field_with_options_for_scalar_types():
         )
         result = generator._generate_field(field)
         assert result == expected
+
+
+def test_generate_service_with_additional_bindings():
+    """Test that a service with additional_bindings in google.api.http option is generated correctly."""
+    service = ast.Service(
+        name="LeaseService",
+        elements=[
+            ast.Method(
+                name="LeaseRevoke",
+                input_type=ast.MessageType(type="LeaseRevokeRequest", stream=False),
+                output_type=ast.MessageType(type="LeaseRevokeResponse", stream=False),
+                elements=[
+                    ast.Option(
+                        name="(google.api.http)",
+                        value=ast.MessageLiteral(
+                            fields=[
+                                ast.MessageLiteralField(
+                                    name="post",
+                                    value="/v3/lease/revoke"
+                                ),
+                                ast.MessageLiteralField(
+                                    name="body",
+                                    value="*"
+                                ),
+                                ast.MessageLiteralField(
+                                    name="additional_bindings",
+                                    value=ast.MessageLiteral(
+                                        fields=[
+                                            ast.MessageLiteralField(
+                                                name="post",
+                                                value="/v3/kv/lease/revoke"
+                                            ),
+                                            ast.MessageLiteralField(
+                                                name="body",
+                                                value="*"
+                                            )
+                                        ]
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                ]
+            )
+        ]
+    )
+
+    result = Generator()._generate_service(service)
+    expected = (
+        "service LeaseService {\n"
+        "  rpc LeaseRevoke (LeaseRevokeRequest) returns (LeaseRevokeResponse) {\n"
+        '    option (google.api.http) = {\n'
+        '      post: "/v3/lease/revoke",\n'
+        '      body: "*",\n'
+        '      additional_bindings: {\n'
+        '        post: "/v3/kv/lease/revoke",\n'
+        '        body: "*"\n'
+        "      }\n"
+        "    };\n"
+        "  }\n"
+        "}"
+    )
+
+    assert result == expected

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1165,7 +1165,7 @@ def test_generate_field_with_options_for_scalar_types():
 def test_generate_service_with_additional_bindings():
     """Test that a service with additional_bindings in google.api.http option is generated correctly."""
     service = ast.Service(
-        name="LeaseService",
+        name="Lease",
         elements=[
             ast.Method(
                 name="LeaseRevoke",
@@ -1209,7 +1209,7 @@ def test_generate_service_with_additional_bindings():
 
     result = Generator()._generate_service(service)
     expected = (
-        "service LeaseService {\n"
+        "service Lease {\n"
         "  rpc LeaseRevoke (LeaseRevokeRequest) returns (LeaseRevokeResponse) {\n"
         '    option (google.api.http) = {\n'
         '      post: "/v3/lease/revoke",\n'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1593,3 +1593,71 @@ def test_parse_bool_options():
     )
 
     assert result == expected
+
+
+def test_parse_service_with_additional_bindings():
+    """Test parsing a service with additional_bindings in google.api.http option."""
+    text = '''
+    service Lease {
+        rpc LeaseRevoke(LeaseRevokeRequest) returns (LeaseRevokeResponse) {
+            option (google.api.http) = {
+                post: "/v3/lease/revoke"
+                body: "*"
+                additional_bindings {
+                    post: "/v3/kv/lease/revoke"
+                    body: "*"
+                }
+            };
+        }
+    }
+    '''
+    result = Parser().parse(text)
+    expected = ast.File(
+        syntax=None,
+        file_elements=[
+            ast.Service(
+                name="Lease",
+                elements=[
+                    ast.Method(
+                        name="LeaseRevoke",
+                        input_type=ast.MessageType(type="LeaseRevokeRequest", stream=False),
+                        output_type=ast.MessageType(type="LeaseRevokeResponse", stream=False),
+                        elements=[
+                            ast.Option(
+                                name="(google.api.http)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="post",
+                                            value="/v3/lease/revoke"
+                                        ),
+                                        ast.MessageLiteralField(
+                                            name="body",
+                                            value="*"
+                                        ),
+                                        ast.MessageLiteralField(
+                                            name="additional_bindings",
+                                            value=ast.MessageLiteral(
+                                                fields=[
+                                                    ast.MessageLiteralField(
+                                                        name="post",
+                                                        value="/v3/kv/lease/revoke"
+                                                    ),
+                                                    ast.MessageLiteralField(
+                                                        name="body",
+                                                        value="*"
+                                                    )
+                                                ]
+                                            )
+                                        )
+                                    ]
+                                )
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    assert result == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1597,7 +1597,7 @@ def test_parse_bool_options():
 
 def test_parse_service_with_additional_bindings():
     """Test parsing a service with additional_bindings in google.api.http option."""
-    text = '''
+    text = """
     service Lease {
         rpc LeaseRevoke(LeaseRevokeRequest) returns (LeaseRevokeResponse) {
             option (google.api.http) = {
@@ -1610,7 +1610,7 @@ def test_parse_service_with_additional_bindings():
             };
         }
     }
-    '''
+    """
     result = Parser().parse(text)
     expected = ast.File(
         syntax=None,
@@ -1620,44 +1620,43 @@ def test_parse_service_with_additional_bindings():
                 elements=[
                     ast.Method(
                         name="LeaseRevoke",
-                        input_type=ast.MessageType(type="LeaseRevokeRequest", stream=False),
-                        output_type=ast.MessageType(type="LeaseRevokeResponse", stream=False),
+                        input_type=ast.MessageType(
+                            type="LeaseRevokeRequest", stream=False
+                        ),
+                        output_type=ast.MessageType(
+                            type="LeaseRevokeResponse", stream=False
+                        ),
                         elements=[
                             ast.Option(
                                 name="(google.api.http)",
                                 value=ast.MessageLiteral(
                                     fields=[
                                         ast.MessageLiteralField(
-                                            name="post",
-                                            value="/v3/lease/revoke"
+                                            name="post", value="/v3/lease/revoke"
                                         ),
-                                        ast.MessageLiteralField(
-                                            name="body",
-                                            value="*"
-                                        ),
+                                        ast.MessageLiteralField(name="body", value="*"),
                                         ast.MessageLiteralField(
                                             name="additional_bindings",
                                             value=ast.MessageLiteral(
                                                 fields=[
                                                     ast.MessageLiteralField(
                                                         name="post",
-                                                        value="/v3/kv/lease/revoke"
+                                                        value="/v3/kv/lease/revoke",
                                                     ),
                                                     ast.MessageLiteralField(
-                                                        name="body",
-                                                        value="*"
-                                                    )
+                                                        name="body", value="*"
+                                                    ),
                                                 ]
-                                            )
-                                        )
+                                            ),
+                                        ),
                                     ]
-                                )
+                                ),
                             )
-                        ]
+                        ],
                     )
-                ]
+                ],
             )
-        ]
+        ],
     )
 
     assert result == expected


### PR DESCRIPTION
The parser didn't support a message literal made up of a list of message literals. This is valid syntax that's captured in the `.g4` and used by protobuf definitions such as etcd (see #45). The parser is updated to handle this style. I've also added a test to the generator to verify that everything works as expected, which it does.

Fixes #45 