### PR TITLE
Removes debugging print statement from generator

### DIFF
--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -132,7 +132,6 @@ class Generator:
             cardinality = f"{field.cardinality.value.lower()} "
 
         options = ""
-        print(field.options)
         if field.options:
             options = " ["
             options += ", ".join(


### PR DESCRIPTION
Thanks for the great project, currently using it and it's working great.

The current generator prints `[]`, I think this was just a left over print statement for the latest options issue.

Really simple PR 😄 

```
>>> w = Generator().generate(ast)
[]
[]
[]
[]
[]
[]
```

Sorry for the duplicate!