### PR TITLE
Support complex option parsing

### DIFF
--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -347,7 +347,7 @@ class _ASTConstructor(ProtobufParserVisitor):
 
     def visitAlwaysIdent(self, ctx: ProtobufParser.AlwaysIdentContext):
         if ctx.IDENTIFIER():
-            # Unlike string/int/float, bools are just reated as identiifers in
+            # Unlike string/int/float, bools are just treated as identifiers in
             # the lexer, so we need to handle them here
             identifier_text = self._getText(ctx)
             if identifier_text in ["true", "false"]:

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -128,8 +128,8 @@ class _ASTConstructor(ProtobufParserVisitor):
         )
 
     def visitCompactOption(self, ctx: ProtobufParser.CompactOptionContext):
-        name = self._getText(ctx.optionName())
-        value = self._stringToType(self._getText(ctx.optionValue()))
+        name = _ASTConstructor.normalize_option_name(self._getText(ctx.optionName()))
+        value = self.visit(ctx.optionValue())
         return ast.Option(name=name, value=value)
 
     def visitCompactOptions(self, ctx: ProtobufParser.CompactOptionsContext):

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -369,7 +369,12 @@ class _ASTConstructor(ProtobufParserVisitor):
             ctx.stop.stop,
         )  # pyright: ignore [reportGeneralTypeIssues]
         text = input_stream.getText(start, stop)
-        text = text.strip('"') if strip_quotes else text
+        if (
+            strip_quotes
+            and (text.startswith('"') and text.endswith('"'))
+            or (text.startswith("'") and text.endswith("'"))
+        ):
+            text = text[1:-1]
         return text
 
     def _stringToType(self, value: str):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1794,7 +1794,6 @@ def test_parse_complex_compact_option_with_escaped_string():
     assert result == expected
 
 
-
 def test_parse_email_compact_option_with_escaped_string():
     text_with_email = """
     syntax = "proto3";

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1732,7 +1732,8 @@ def test_parse_complex_compact_option():
                                 value=ast.MessageLiteral(
                                     fields=[
                                         ast.MessageLiteralField(
-                                            name="example", value="mini@mouse.com"
+                                            name="example",
+                                            value="mini@mouse.com",
                                         )
                                     ]
                                 ),
@@ -1753,11 +1754,13 @@ def test_parse_complex_compact_option_with_escaped_string():
     message Foo {
       string bar = 4 [
         (oompa.loompa) = {
-          example: "\"blah\"";
+          example: "\\"blah\\"";
         }
       ];
     }
     """
+
+    print(text_with_email)
 
     result = Parser().parse(text_with_email)
     expected = ast.File(
@@ -1777,7 +1780,55 @@ def test_parse_complex_compact_option_with_escaped_string():
                                     fields=[
                                         ast.MessageLiteralField(
                                             name="example",
-                                            value='"blah"',
+                                            value='\\"blah\\"',
+                                        )
+                                    ]
+                                ),
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert result == expected
+
+
+
+def test_parse_email_compact_option_with_escaped_string():
+    text_with_email = """
+    syntax = "proto3";
+
+    message Foo {
+      string bar = 4 [
+        (oompa.loompa) = {
+          example: "\\"mini@mouse.com\\"";
+        }
+      ];
+    }
+    """
+
+    print(text_with_email)
+
+    result = Parser().parse(text_with_email)
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Message(
+                name="Foo",
+                elements=[
+                    ast.Field(
+                        name="bar",
+                        number=4,
+                        type="string",
+                        options=[
+                            ast.Option(
+                                name="(oompa.loompa)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="example",
+                                            value='\\"mini@mouse.com\\"',
                                         )
                                     ]
                                 ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1703,11 +1703,6 @@ def test_syntax_error():
 
 
 def test_parse_complex_compact_option():
-    """
-    Test that demonstrates a bug with parsing example directives containing email addresses.
-    The parser fails when the example value contains an email address with @ symbol.
-    """
-    # This proto definition fails to parse due to the email address in the example
     text_with_email = """
     syntax = "proto3";
 
@@ -1738,6 +1733,51 @@ def test_parse_complex_compact_option():
                                     fields=[
                                         ast.MessageLiteralField(
                                             name="example", value="mini@mouse.com"
+                                        )
+                                    ]
+                                ),
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert result == expected
+
+
+def test_parse_complex_compact_option_with_escaped_string():
+    text_with_email = """
+    syntax = "proto3";
+
+    message Foo {
+      string bar = 4 [
+        (oompa.loompa) = {
+          example: "\"blah\"";
+        }
+      ];
+    }
+    """
+
+    result = Parser().parse(text_with_email)
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Message(
+                name="Foo",
+                elements=[
+                    ast.Field(
+                        name="bar",
+                        number=4,
+                        type="string",
+                        options=[
+                            ast.Option(
+                                name="(oompa.loompa)",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="example",
+                                            value='"blah"',
                                         )
                                     ]
                                 ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1693,7 +1693,7 @@ def test_syntax_error():
     )
 
 
-def test_parse_example_with_email():
+def test_parse_complex_compact_option():
     """
     Test that demonstrates a bug with parsing example directives containing email addresses.
     The parser fails when the example value contains an email address with @ symbol.
@@ -1705,12 +1705,12 @@ def test_parse_example_with_email():
     message Foo {
       string bar = 4 [
         (oompa.loompa) = {
-          example: "\"mini@mouse.com\"";
+          example: "mini@mouse.com";
         }
       ];
     }
     """
-    
+
     result = Parser().parse(text_with_email)
     expected = ast.File(
         syntax="proto3",
@@ -1725,51 +1725,7 @@ def test_parse_example_with_email():
                         options=[
                             ast.Option(
                                 name="(oompa.loompa)",
-                                value={"example": '"mini@mouse.com"'},
-                            )
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-    assert result == expected
-
-
-def test_parse_description_with_email():
-    """
-    Test that demonstrates a bug with parsing description directives containing email addresses.
-    The parser fails when the description value contains an email address with @ symbol.
-    """
-    # This proto definition fails to parse due to the email address in the description
-    text_with_email = """
-    syntax = "proto3";
-
-    message Foo {
-      string bar = 4 [
-        (oompa.loompa) = {
-          description: "\"Contact us at mini@mouse.com\"";
-        }
-      ];
-    }
-    """
-
-    # This parses successfully
-    result = Parser().parse(text_with_email)
-    expected = ast.File(
-        syntax="proto3",
-        file_elements=[
-            ast.Message(
-                name="Foo",
-                elements=[
-                    ast.Field(
-                        name="bar",
-                        number=4,
-                        type="string",
-                        options=[
-                            ast.Option(
-                                name="(oompa.loompa)",
-                                value={"description": '"Contact us at mini@mouse.com"'},
+                                value={"example": "mini@mouse.com"},
                             )
                         ],
                     ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,7 +98,11 @@ def test_parse_person():
                                 number=2,
                                 cardinality=ast.FieldCardinality.OPTIONAL,
                                 type="PhoneType",
-                                options=[ast.Option(name="default", value="HOME")],
+                                options=[
+                                    ast.Option(
+                                        name="default", value=ast.Identifier("HOME")
+                                    )
+                                ],
                             ),
                         ],
                     ),
@@ -142,7 +146,12 @@ def test_parse_search_request():
                         options=[
                             ast.Option(
                                 name="(validate.rules).double",
-                                value="{gte: -90,  lte: 90}",
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(name="gte", value=-90),
+                                        ast.MessageLiteralField(name="lte", value=90),
+                                    ]
+                                ),
                             )
                         ],
                     ),
@@ -1725,7 +1734,13 @@ def test_parse_complex_compact_option():
                         options=[
                             ast.Option(
                                 name="(oompa.loompa)",
-                                value={"example": "mini@mouse.com"},
+                                value=ast.MessageLiteral(
+                                    fields=[
+                                        ast.MessageLiteralField(
+                                            name="example", value="mini@mouse.com"
+                                        )
+                                    ]
+                                ),
                             )
                         ],
                     ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1691,3 +1691,90 @@ def test_syntax_error():
         exc_info.value.args[0]
         == r"Failed to parse: line 6:4: mismatched input '}' expecting {';', '['}"
     )
+
+
+def test_parse_example_with_email():
+    """
+    Test that demonstrates a bug with parsing example directives containing email addresses.
+    The parser fails when the example value contains an email address with @ symbol.
+    """
+    # This proto definition fails to parse due to the email address in the example
+    text_with_email = """
+    syntax = "proto3";
+
+    message Foo {
+      string bar = 4 [
+        (oompa.loompa) = {
+          example: "\"mini@mouse.com\"";
+        }
+      ];
+    }
+    """
+    
+    result = Parser().parse(text_with_email)
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Message(
+                name="Foo",
+                elements=[
+                    ast.Field(
+                        name="bar",
+                        number=4,
+                        type="string",
+                        options=[
+                            ast.Option(
+                                name="(oompa.loompa)",
+                                value={"example": '"mini@mouse.com"'},
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert result == expected
+
+
+def test_parse_description_with_email():
+    """
+    Test that demonstrates a bug with parsing description directives containing email addresses.
+    The parser fails when the description value contains an email address with @ symbol.
+    """
+    # This proto definition fails to parse due to the email address in the description
+    text_with_email = """
+    syntax = "proto3";
+
+    message Foo {
+      string bar = 4 [
+        (oompa.loompa) = {
+          description: "\"Contact us at mini@mouse.com\"";
+        }
+      ];
+    }
+    """
+
+    # This parses successfully
+    result = Parser().parse(text_with_email)
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Message(
+                name="Foo",
+                elements=[
+                    ast.Field(
+                        name="bar",
+                        number=4,
+                        type="string",
+                        options=[
+                            ast.Option(
+                                name="(oompa.loompa)",
+                                value={"description": '"Contact us at mini@mouse.com"'},
+                            )
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert result == expected


### PR DESCRIPTION
This patch adds proper parsing for complex options like:

```protobuf
syntax = "proto3";

message Foo {
  string bar = 4 [
    (oompa.loompa) = {
      example: "\\"mini@mouse.com\\"";
    }
  ];
}
```

This is a backwards-incompatible change because old string values now show up as `Identifier`s.

Fixes #52