### PR TITLE
Add parsing of extension field declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .pdm-python
+
+# IDEs
+.vscode

--- a/proto_schema_parser/antlr/ProtobufParser.py
+++ b/proto_schema_parser/antlr/ProtobufParser.py
@@ -6729,7 +6729,7 @@ class ProtobufParser ( Parser ):
         def R_BRACE(self):
             return self.getToken(ProtobufParser.R_BRACE, 0)
 
-        def extensionElement(self, i:int=None):
+        def extensionElement(self, i:int|None=None):
             if i is None:
                 return self.getTypedRuleContexts(ProtobufParser.ExtensionElementContext)
             else:

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -246,6 +246,21 @@ class _ASTConstructor(ProtobufParserVisitor):
         elements = [self.visit(child) for child in ctx.extensionElement()]
         return ast.Extension(typeName=typeName, elements=elements)
 
+    def visitExtensionFieldDecl(self, ctx: ProtobufParser.ExtensionFieldDeclContext):
+        if fieldWithCardinality := ctx.fieldDeclWithCardinality():
+            return self.visit(fieldWithCardinality)
+        else:
+            name = self._getText(ctx.fieldName())
+            number = int(self._getText(ctx.fieldNumber()))
+            type = self._getText(ctx.extensionFieldDeclTypeName())
+            options = self.visit(ctx.compactOptions()) if ctx.compactOptions() else []
+            return ast.Field(
+                name=name,
+                number=number,
+                type=type,
+                options=options,
+            )
+
     def visitServiceDecl(self, ctx: ProtobufParser.ServiceDeclContext):
         name = self._getText(ctx.serviceName())
         elements = [self.visit(child) for child in ctx.serviceElement()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proto-schema-parser"
-version = "1.6.0"
+version = "1.7.0"
 description = "A Pure Python Protobuf .proto Parser"
 authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -436,6 +436,80 @@ def test_parse_extension():
     assert result == expected
 
 
+def test_parse_option_extension_with_message():
+    text = """
+    syntax = "proto3";
+    package test.options.v1;
+
+    message Version
+    {
+        required uint32 major = 1;
+        required uint32 minor = 2;
+    }
+
+    message ServiceOptions {
+        extensions 1000 to max;
+    }
+
+    extend ServiceOptions
+    {
+        Version version = 1001;
+    }
+    """
+    result = Parser().parse(text)
+    expected = ast.File(
+        syntax="proto3",
+        file_elements=[
+            ast.Package(
+                name="test.options.v1",
+            ),
+            ast.Message(
+                name="Version",
+                elements=[
+                    ast.Field(
+                        name="major",
+                        number=1,
+                        type="uint32",
+                        cardinality=ast.FieldCardinality.REQUIRED,
+                        options=[],
+                    ),
+                    ast.Field(
+                        name="minor",
+                        number=2,
+                        type="uint32",
+                        cardinality=ast.FieldCardinality.REQUIRED,
+                        options=[],
+                    ),
+                ],
+            ),
+            ast.Message(
+                name="ServiceOptions",
+                elements=[
+                    ast.ExtensionRange(
+                        ranges=[
+                            "1000 to max",
+                        ],
+                        options=[],
+                    ),
+                ],
+            ),
+            ast.Extension(
+                typeName="ServiceOptions",
+                elements=[
+                    ast.Field(
+                        name="version",
+                        number=1001,
+                        cardinality=None,
+                        type="Version",
+                        options=[],
+                    ),
+                ],
+            ),
+        ],
+    )
+    assert result == expected
+
+
 def test_parse_imports():
     text = """
     syntax = "proto3";


### PR DESCRIPTION
proto3 still uses extensions for custom options. this PR adds parsing of extension fields

Fixes #55