### PR TITLE
Add exhaustive support for trailing comments

### DIFF
--- a/proto_schema_parser/ast.py
+++ b/proto_schema_parser/ast.py
@@ -92,21 +92,39 @@ class MessageLiteralField:
     value: MessageValue
 
 
-@dataclass
+@dataclass(init=False)
 class MessageLiteral:
     """
     Represents a message literal.
 
     Attributes:
-        fields: List[MessageLiteralField]
-            The fields of the message literal.
         elements: List[MessageTextElement]
             The ordered elements (fields and comments) inside the literal.
             This preserves inline/trailing comments within braces.
     """
 
-    fields: List[MessageLiteralField] = field(default_factory=list)
-    elements: List["MessageTextElement"] = field(default_factory=list, compare=False)
+    elements: List["MessageTextElement"] = field(default_factory=list)
+
+    def __init__(
+        self,
+        *,
+        elements: List["MessageTextElement"] | None = None,
+        fields: List["MessageLiteralField"] | None = None,
+    ) -> None:
+        if elements is not None:
+            self.elements = elements
+        elif fields is not None:
+            # Backward-compat constructor arg; store only in elements
+            self.elements = list(fields)
+        else:
+            self.elements = []
+
+    @property
+    def fields(self) -> List["MessageLiteralField"]:
+        """Convenience view of only the field elements (read-only)."""
+        return [
+            e for e in self.elements if isinstance(e, MessageLiteralField)
+        ]
 
 
 # optionDecl: OPTION optionName EQUALS optionValue SEMICOLON;

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -235,11 +235,7 @@ class Generator:
     ) -> str:
         """Generate nested message literal with consistent indentation."""
         # Prefer ordered elements if present; fall back to fields
-        elems = (
-            message_literal.elements
-            if getattr(message_literal, "elements", None)
-            else list(message_literal.fields)
-        )
+        elems = message_literal.elements
 
         # Fallback to fields-only inline generation if no comments are present
         if inline:
@@ -249,12 +245,12 @@ class Generator:
                 inline = False  # degrade to multi-line to retain comments
             else:
                 field_strings = []
-                for field in elems:  # type: ignore[assignment]
-                    assert isinstance(field, ast.MessageLiteralField)
+                for element in elems:
+                    assert isinstance(element, ast.MessageLiteralField)
                     value = self._generate_option_value(
-                        field.value, indent_level, inline=True
+                        element.value, indent_level, inline=True
                     )
-                    field_strings.append(f"{field.name}: {value}")
+                    field_strings.append(f"{element.name}: {value}")
                 return "{ " + ", ".join(field_strings) + " }"
 
         lines = [f"{'  ' * indent_level}{{"]

--- a/proto_schema_parser/parser.py
+++ b/proto_schema_parser/parser.py
@@ -78,9 +78,7 @@ class _ASTConstructor(ProtobufParserVisitor):
                 elif isinstance(child, ProtobufParser.CommentDeclContext):
                     elements.append(self.visit(child))  # ast.Comment
 
-        # Backward compatibility: still populate 'fields'
-        only_fields = [e for e in elements if isinstance(e, ast.MessageLiteralField)]
-        return ast.MessageLiteral(fields=only_fields, elements=elements)
+        return ast.MessageLiteral(elements=elements)
 
     def visitMessageLiteralField(self, ctx: ProtobufParser.MessageLiteralFieldContext):
         """Parse individual fields inside a message literal."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -757,7 +757,7 @@ def test_generate_option_with_simple_message_literal():
     option = ast.Option(
         name="my_option",
         value=ast.MessageLiteral(
-            fields=[
+            elements=[
                 ast.MessageLiteralField(name="field1", value="value1"),
                 ast.MessageLiteralField(name="field2", value=42),
             ]
@@ -823,7 +823,7 @@ def test_generate_option_with_list_literal():
 def test_generate_option_with_empty_message_literal():
     option = ast.Option(
         name="empty_option",
-        value=ast.MessageLiteral(fields=[]),
+        value=ast.MessageLiteral(elements=[]),
     )
 
     result = Generator()._generate_option(option)
@@ -1540,7 +1540,7 @@ def test_generate_option_with_complex_nested_message_literal_swagger():
                                                 ),
                                                 ast.MessageLiteralField(
                                                     name="value",
-                                                    value=ast.MessageLiteral(fields=[]),
+                                                    value=ast.MessageLiteral(elements=[]),
                                                 ),
                                             ]
                                         ),
@@ -1641,7 +1641,7 @@ def test_generate_multiple_options_with_complex_message_literals():
                                                 ),
                                                 ast.MessageLiteralField(
                                                     name="value",
-                                                    value=ast.MessageLiteral(fields=[]),
+                                                    value=ast.MessageLiteral(elements=[]),
                                                 ),
                                             ]
                                         ),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -147,7 +147,7 @@ def test_parse_search_request():
                             ast.Option(
                                 name="(validate.rules).double",
                                 value=ast.MessageLiteral(
-                                    fields=[
+                                    elements=[
                                         ast.MessageLiteralField(name="gte", value=-90),
                                         ast.MessageLiteralField(name="lte", value=90),
                                     ]
@@ -1232,7 +1232,10 @@ def test_comments_on_service_and_options():
                             ast.Option(
                                 name="(google.api.http)",
                                 value=ast.MessageLiteral(
-                                    fields=[
+                                    elements=[
+                                        ast.Comment(
+                                            text="// some comment about the option"
+                                        ),
                                         ast.MessageLiteralField(
                                             name="get",
                                             value="/v1/search/{query}",
@@ -1750,13 +1753,17 @@ def test_option_with_comments_and_fields():
                             ast.Option(
                                 name="(test.option)",
                                 value=ast.MessageLiteral(
-                                    fields=[
+                                    elements=[
+                                        ast.Comment(
+                                            text="// Comment about the field"
+                                        ),
                                         ast.MessageLiteralField(
                                             name="field1", value="value1"
                                         ),
                                         ast.MessageLiteralField(
                                             name="field2", value=99
                                         ),
+                                        ast.Comment(text="// Another comment"),
                                     ]
                                 ),
                             )


### PR DESCRIPTION
There were some gaps where trailing comments weren't supported. There are now fairly extensive tests that verify trailing comments work. Where the tests failed, the ast/parser/generator were fixed.

Fixes #62